### PR TITLE
Prevent app from exiting before writes complete.

### DIFF
--- a/esrislurp.js
+++ b/esrislurp.js
@@ -96,10 +96,10 @@ module.exports = function(basePath, version, beautify, onSuccess, onError, onPro
           if(err){
             console.warn(err);
           }
+          signalProgessUpdate();
+          callback(error, body);
         });
 
-        signalProgessUpdate();
-        callback(error, body);
       });
   }, function(err) {
     if (err) {


### PR DESCRIPTION
Tested in Node v0.10.37 and v0.12.0. Works as expected. Fixes intermittent error completing write to the last file in the array (utils.js for esri jsapi 3.9).