### PR TITLE
Fix async issue in newer Node versions

### DIFF
--- a/esrislurp.js
+++ b/esrislurp.js
@@ -96,10 +96,10 @@ module.exports = function(basePath, version, beautify, onSuccess, onError, onPro
           if(err){
             console.warn(err);
           }
+          signalProgessUpdate();
+          callback(error, body);
         });
 
-        signalProgessUpdate();
-        callback(error, body);
       });
   }, function(err) {
     if (err) {


### PR DESCRIPTION
Changes allow script to reuse open connections to avoid saturating TCP connections to the download server. Check for body.length changed to test for existence of body--when responseStatus is 404, body is zero and length is undefined. 

Moved eachLimit's callback inside of the writeFile method so limit is actually tied to the asynchronous event. In prior testing having the callback outside of writeFile caused the script to end prematurely, before the last file was written to disk, in some environments. I've been running this change for two months without one error related to premature ending leaving the last file empty (see [issue #31](https://github.com/steveoh/grunt-esri-slurp/issues/31) on grunt-esri-slurp)